### PR TITLE
Release v2.0.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Note that the host must be reachable from within this container.
 # ELASTIC_INIT_ES_HOST=http://127.0.0.1
 # ELASTIC_INIT_ES_PORT=9200
-ELASTIC_INIT_ONTO_GIT_TAG=v3.0.1
+ELASTIC_INIT_ONTO_GIT_TAG=v4.0.0
 # ELASTIC_INIT_ONTO_REPO=https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download
 # ELASTIC_INIT_DOWNLOAD_FILENAME=elastic.zip
 # ELASTIC_INIT_EXIT_ON_EXISTING_INDICES=false
+# FORCE_REINSTALL=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-02-27
+### Added
+- Compare installed version and update candidate version of the ontology and only update newer files
+- FORCE_REINSTALL parameter added to override the version nr check and always delete and reinstall
+### Changed
+- BREAKING: Since the version numbers in the ontology files are only provided from 4.0.0 up, this is required. For older versions use 1.x of this tool
+### Removed
+- EXIT_ON_EXISTING_INDICES parameter is obsolete since the version check makes more sense
+
 ## [1.2.1] - 2025-01-21
 ### Changed
 - The option to use a mounted file is now implicit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM curlimages/curl:8.18.0@sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17
 
+USER root
+RUN apk add --no-cache bash jq
+
 WORKDIR /home/curl_user
 COPY ./elastic-init.sh elastic-init.sh
 
-ENTRYPOINT ["/home/curl_user/elastic-init.sh"]
+RUN chmod +x elastic-init.sh
+
+ENTRYPOINT ["bash", "/home/curl_user/elastic-init.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69
+FROM curlimages/curl:8.13.0@sha256:d43bdb28bae0be0998f3be83199bfb2b81e0a30b034b6d7586ce7e05de34c3fd
 
 WORKDIR /home/curl_user
 COPY ./elastic-init.sh elastic-init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM curlimages/curl:8.13.0@sha256:d43bdb28bae0be0998f3be83199bfb2b81e0a30b034b6d7586ce7e05de34c3fd
+FROM curlimages/curl:8.18.0@sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17
 
 WORKDIR /home/curl_user
 COPY ./elastic-init.sh elastic-init.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The primary purpose of this project is to automate the setup of the Elasticsearc
 
 - **Docker**: Ensure Docker is installed and running on your system.
 - **Elasticsearch**: A running instance of Elasticsearch to receive the index definitions and documents. The REST api of the elasticsearch instance must be reachable from within this container
+- Ontology version v4.0.0 or later. Previous versions don't provide their version number in the indices. If you need to run on older versions, please use version 1.x.x of THIS tool
 
 ## Usage
 
@@ -36,7 +37,7 @@ To use this Docker image, follow these steps:
               -e ONTO_REPO=<onto_repo> \
               -e ONTO_RELATIVE_PATH=<onto_relative_path> \
               -e DOWNLOAD_FILENAME=<download_filename> \
-              -e EXIT_ON_EXISTING_INDICES=false \
+              -e FORCE_REINSTALL=false \
               dataportal-es-init:latest
    ```
 
@@ -49,7 +50,7 @@ The Docker image supports several environment variables for configuration. The o
 - `ONTO_GIT_TAG`: The tag of the [FHIR Ontology Generator](https://github.com/medizininformatik-initiative/fhir-ontology-generator) files to use.
 - `ONTO_REPO`: Base URL to the ontology generator repository (default: `https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download`). Please do **NOT** enter a trailing slash since it will be inserted in the script.
 - `DOWNLOAD_FILENAME`: The filename to get (default: `elastic.zip`)
-- `EXIT_ON_EXISTING_INDEX`: If set to true, the container will shut down without doing anything if at least one of both indices (`ontology` and `codeable_concept`) exists (default: false)
+- `FORCE_REINSTALL`: If set to true, both indices in the elasticsearch container will be deleted and freshly created from the files in the downloaded (or provided) zip file.
 
 ## Examples
 
@@ -61,7 +62,7 @@ This is the default setting. Provide the git tag of the ontology you want to dow
 
 ```bash
 docker run --network host \
-           -e ONTO_GIT_TAG=v3.0.1 \
+           -e ONTO_GIT_TAG=v4.0.0 \
            ghcr.io/medizininformatik-initiative/dataportal-es-init:latest
 ```
 which would be equivalent to
@@ -70,16 +71,17 @@ which would be equivalent to
 docker run --network host \
            -e ES_HOST=http://127.0.0.1 \
            -e ES_PORT=9200 \
-           -e ONTO_GIT_TAG=v3.0.1 \
+           -e ONTO_GIT_TAG=v4.0.0 \
            -e ONTO_REPO=https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download \
            -e DOWNLOAD_FILENAME=elastic.zip \
-           -e EXIT_ON_EXISTING_INDICES=false \
+           -e FORCE_REINSTALL=false \
            dataportal-es-init:latest
 ```
 
 ### Providing a local archive file via mount
 
-In case you want to use a local file on your machine instead of downloading from GitHub (or elsewhere), you must mount a valid zip file to `/tmp/mounted_onto.zip` in the container
+In case you want to use a local file on your machine instead of downloading from GitHub (or elsewhere), you must mount a valid zip file to `/tmp/mounted_onto.zip` in the container. This filename is fixed.
+**Important since v2**: Make sure that your locally provided file also contains the version information in the _meta part of the indices. Or set `FORCE_REINSTALL` to true to always delete and reinstall the indices.
 
 ```bash
 docker run --network host \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,9 @@ services:
       ONTO_GIT_TAG: ${ELASTIC_INIT_ONTO_GIT_TAG}
       ONTO_REPO: ${ELASTIC_INIT_ONTO_REPO}
       DOWNLOAD_FILENAME: ${ELASTIC_INIT_DOWNLOAD_FILENAME}
-      EXIT_ON_EXISTING_INDICES: ${ELASTIC_INIT_EXIT_ON_EXISTING_INDICES}
+      FORCE_REINSTALL: ${ELASTIC_INIT_FORCE_REINSTALL}
+#    volumes:
+#      - type: bind
+#        source: /tmp/elastic.zip
+#        target: /tmp/mounted_onto.zip
+#        read_only: true

--- a/elastic-init.sh
+++ b/elastic-init.sh
@@ -1,12 +1,106 @@
-#!/bin/sh
+#!/bin/bash
 
+# Compare function from https://stackoverflow.com/a/44660519
+
+# Compares two dot-delimited decimal-element version numbers a and b that may
+# also have arbitrary string suffixes. Compatible with semantic versioning, but
+# not as strict: comparisons of non-semver strings may have unexpected
+# behavior.
+#
+# Returns:
+# 1 if a<b
+# 2 if equal
+# 3 if a>b
+compare_versions() {
+    local LC_ALL=C
+
+    # Optimization
+    if [[ $1 == "$2" ]]; then
+        return 2
+    fi
+
+    # Compare numeric release versions. Supports an arbitrary number of numeric
+    # elements (i.e., not just X.Y.Z) in which unspecified indices are regarded
+    # as 0.
+    local aver=${1%%[^0-9.]*} bver=${2%%[^0-9.]*}
+    local arem=${1#$aver} brem=${2#$bver}
+    local IFS=.
+    local i a=($aver) b=($bver)
+    for ((i=0; i<${#a[@]} || i<${#b[@]}; i++)); do
+        if ((10#${a[i]:-0} < 10#${b[i]:-0})); then
+            return 1
+        elif ((10#${a[i]:-0} > 10#${b[i]:-0})); then
+            return 3
+        fi
+    done
+
+    # Remove build metadata before remaining comparison
+    arem=${arem%%+*}
+    brem=${brem%%+*}
+
+    # Prelease (w/remainder) always older than release (no remainder)
+    if [ -n "$arem" -a -z "$brem" ]; then
+        return 1
+    elif [ -z "$arem" -a -n "$brem" ]; then
+        return 3
+    fi
+
+    # Otherwise, split by periods and compare individual elements either
+    # numerically or lexicographically
+    local a=(${arem#-}) b=(${brem#-})
+    for ((i=0; i<${#a[@]} && i<${#b[@]}; i++)); do
+        local anns=${a[i]#${a[i]%%[^0-9]*}} bnns=${b[i]#${b[i]%%[^0-9]*}}
+        if [ -z "$anns$bnns" ]; then
+            # Both numeric
+            if ((10#${a[i]:-0} < 10#${b[i]:-0})); then
+                return 1
+            elif ((10#${a[i]:-0} > 10#${b[i]:-0})); then
+                return 3
+            fi
+        elif [ -z "$anns" ]; then
+            # Numeric comes before non-numeric
+            return 1
+        elif [ -z "$bnns" ]; then
+            # Numeric comes before non-numeric
+            return 3
+        else
+            # Compare lexicographically
+            if [[ ${a[i]} < ${b[i]} ]]; then
+                return 1
+            elif [[ ${a[i]} > ${b[i]} ]]; then
+                return 3
+            fi
+        fi
+    done
+
+    # Fewer elements is earlier
+    if (( ${#a[@]} < ${#b[@]} )); then
+        return 1
+    elif (( ${#a[@]} > ${#b[@]} )); then
+        return 3
+    fi
+
+    # Must be equal!
+    return 2
+}
+
+normalize_version() {
+  echo "$1" | sed 's/^v//'
+}
+
+# ANSI color codes
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+NC="\033[0m"
 HOST="${ES_HOST:-http://127.0.0.1}:${ES_PORT:-9200}"
 REPO="${ONTO_REPO:-https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download}"
 FILENAME="${DOWNLOAD_FILENAME:-elastic.zip}"
 MOUNTED_FILENAME=/tmp/mounted_onto.zip
 MODE=download
 
-echo "Init container for elastic search - v 1.2.1"
+echo "Init container for elastic search - v 2.0.0"
+
+CURRENT_VERSION=$(curl -s "$HOST/ontology" | jq -r '.ontology.mappings._meta.version')
 
 if [ -f $MOUNTED_FILENAME ]; then
   echo "Mounted file found. Not downloading anything but using the mounted file. If you want to download instead, remove the mounted volume and/or file."
@@ -15,6 +109,14 @@ elif [ -z "$ONTO_GIT_TAG" ]; then
     echo "No mounted file found and no ONTO_GIT_TAG provided. Exiting..."
     exit 1
 else
+  # When downloading, compare versions already to avoid unnecessary downloads
+  V1=$(normalize_version "$CURRENT_VERSION")
+  V2=$(normalize_version "$ONTO_GIT_TAG")
+  compare_versions "$V1" "$V2"
+  if [[ $? -gt 1 && "${FORCE_REINSTALL,,}" != "true" ]]; then
+    echo "Requested version ($ONTO_GIT_TAG) is not newer than the installed one ($CURRENT_VERSION). Set FORCE_REINSTALL to true to override."
+    exit 0
+  fi
   echo "Downloading ${ONTO_GIT_TAG}"
 fi
 
@@ -23,18 +125,6 @@ until curl -X GET "$HOST/_cluster/health" | grep -q '"status":"green"\|"status":
     echo "Waiting for Elasticsearch..."
     sleep 5
 done
-
-if [ "$EXIT_ON_EXISTING_INDICES" = "true" ]; then
-  echo "Checking if ontology or codeable_concept index is existing"
-  status_code_ontology=$(curl -o /dev/null -s -w "%{http_code}" "$HOST/ontology")
-  status_code_cc=$(curl -o /dev/null -s -w "%{http_code}" "$HOST/codeable_concept")
-  if [ "$status_code_ontology" -ne 404 ] || [ "$status_code_cc" -ne 404 ]; then
-    echo "At least one index is existing, and the script is configured to quit in this case. Set EXIT_ON_EXISTING_INDEX to false if you want to override this."
-    exit 0
-  else
-    echo "Neither ontology nor codeable_concept index exists. Download zip file and create indices."
-  fi
-fi
 
 if [ "$MODE" = "download" ]; then
   ABSOLUTE_FILEPATH="${REPO}/${ONTO_GIT_TAG}/${FILENAME}"
@@ -51,6 +141,32 @@ else
   unzip -o "$MOUNTED_FILENAME"
 fi
 
+if [[ "$MODE" = "mount" && -z "$FORCE_REINSTALL" || "${FORCE_REINSTALL,,}" != "true" ]]; then
+  # Compare the version of the installed ontology with the downloaded or provided one.
+  # If the installed one is newer, exit here unless FORCE_REINSTALL is set to true. In that case ignore everything
+  # version-related
+  # There should never be a case where the version of ontology and codeable_concept indices differ. So only ontology is
+  # checked here. Maybe there will be an edge case some day that is not covered here.
+  CURRENT_VERSION=$(curl -s "$HOST/ontology" | jq -r '.ontology.mappings._meta.version')
+  PROVIDED_VERSION=$(< elastic/ontology_index.json jq -r '.mappings._meta.version')
+  V1=$(normalize_version "$CURRENT_VERSION")
+  V2=$(normalize_version "$PROVIDED_VERSION")
+
+  compare_versions "$V1" "$V2"
+  comparison_result=$?
+  case $comparison_result in
+      1) op='<';;
+      2) op='=';;
+      3) op='>';;
+  esac
+
+  if [[ $comparison_result -gt 1 ]]; then
+    echo "Provided version ($PROVIDED_VERSION) is not newer than the installed one ($CURRENT_VERSION). Set FORCE_REINSTALL to true to override."
+    exit 0
+  fi
+else
+  echo "FORCE_REINSTALL is set to true. Not comparing versions, just deleting and reinstalling."
+fi
 
 echo "(Trying to) delete existing indices"
 curl --request DELETE "$HOST/ontology"
@@ -65,19 +181,32 @@ echo "${response_cc}"
 echo "Done"
 
 for FILE in elastic/*; do
-  if [ -f "$FILE" ]; then
+    [[ -f "$FILE" ]] || continue
     BASENAME=$(basename "$FILE")
-    if [[ $BASENAME == onto_es__ontology* && $BASENAME == *.json ]]; then
-      echo "Uploading $BASENAME"
-      response_upload=$(curl --write-out "%{http_code}" -s --output /dev/null -XPOST -H 'Content-Type: application/json' --data-binary @"$FILE" "$HOST/ontology/_bulk")
-      echo "${response_upload}"
+
+    # Only process JSON files starting with onto_es__
+    if [[ "$BASENAME" == onto_es__*.json ]]; then
+        # Extract endpoint: remove prefix and strip version/extension
+        NAME="${BASENAME#onto_es__}"
+        INDEX_PATH="${NAME%_*_*}"
+        INDEX_PATH="${INDEX_PATH%.json}"
+
+        echo -n "Uploading $BASENAME -> "
+
+        # Perform upload
+        response_upload=$(curl --write-out "%{http_code}" -s --output /dev/null \
+                              -XPOST -H 'Content-Type: application/json' \
+                              --data-binary @"$FILE" "$HOST/$INDEX_PATH/_bulk")
+
+        # Color-code HTTP status
+        if [[ "$response_upload" =~ ^2 ]]; then
+            color=$GREEN
+        else
+            color=$RED
+        fi
+
+        echo -e "${color}${response_upload}${NC}"
     fi
-    if [[ $BASENAME == onto_es__codeable_concept* && $BASENAME == *.json ]]; then
-      echo "Uploading $BASENAME"
-      response_upload=$(curl --write-out "%{http_code}" -s --output /dev/null -XPOST -H 'Content-Type: application/json' --data-binary @"$FILE" "$HOST/codeable_concept/_bulk")
-      echo "${response_upload}"
-    fi
-  fi
 done
 
 echo "All done"


### PR DESCRIPTION
## [2.0.0] - 2026-02-27
### Added
- Compare installed version and update candidate version of the ontology and only update newer files
- FORCE_REINSTALL parameter added to override the version nr check and always delete and reinstall
### Changed
- BREAKING: Since the version numbers in the ontology files are only provided from 4.0.0 up, this is required. For older versions use 1.x of this tool
### Removed
- EXIT_ON_EXISTING_INDICES parameter is obsolete since the version check makes more sense